### PR TITLE
dtkReader/Writer do not return/use smartpointers anymore

### DIFF
--- a/src/dtkCoreSupport/dtkAbstractDataReader.cpp
+++ b/src/dtkCoreSupport/dtkAbstractDataReader.cpp
@@ -72,7 +72,6 @@ dtkAbstractData *dtkAbstractDataReader::data(void) const
 
 /**
  * Set the data that has been read.
- * The reader will increase the reference count of the data.
  */
 void dtkAbstractDataReader::setData(dtkAbstractData *data)
 {

--- a/src/dtkCoreSupport/dtkAbstractDataReader_p.h
+++ b/src/dtkCoreSupport/dtkAbstractDataReader_p.h
@@ -34,7 +34,7 @@ class dtkAbstractData;
 class DTKCORESUPPORT_EXPORT dtkAbstractDataReaderPrivate : public dtkAbstractObjectPrivate
 {
 public:
-    dtkAbstractDataReaderPrivate(dtkAbstractDataReader *q = 0) : dtkAbstractObjectPrivate(q) {}
+    dtkAbstractDataReaderPrivate(dtkAbstractDataReader *q = 0) : dtkAbstractObjectPrivate(q), data(NULL) {}
     dtkAbstractDataReaderPrivate(const dtkAbstractDataReaderPrivate& other) : dtkAbstractObjectPrivate(other),
                                                                               enabled(false),
                                                                               data(other.data),
@@ -48,7 +48,7 @@ public:
     bool enabled;
 
 public:
-    dtkSmartPointer<dtkAbstractData> data;
+    dtkAbstractData *data;
 
 public:
     QString file;

--- a/src/dtkCoreSupport/dtkAbstractDataWriter_p.h
+++ b/src/dtkCoreSupport/dtkAbstractDataWriter_p.h
@@ -34,7 +34,7 @@ class dtkAbstractData;
 class DTKCORESUPPORT_EXPORT dtkAbstractDataWriterPrivate : public dtkAbstractObjectPrivate
 {
 public:
-    dtkAbstractDataWriterPrivate(dtkAbstractDataWriter *q = 0) : dtkAbstractObjectPrivate(q) {}
+    dtkAbstractDataWriterPrivate(dtkAbstractDataWriter *q = 0) : dtkAbstractObjectPrivate(q), data(NULL) {}
     dtkAbstractDataWriterPrivate(const dtkAbstractDataWriterPrivate& other) : dtkAbstractObjectPrivate(other),
                                                                               enabled(false),
                                                                               data(other.data) {}
@@ -46,7 +46,7 @@ public:
     bool enabled;
 
 public:
-    dtkSmartPointer<dtkAbstractData> data;
+    dtkAbstractData *data;
 };
 
 ////////////////////////////////////////////////////

--- a/src/dtkCoreSupport/dtkSmartPointer.h
+++ b/src/dtkCoreSupport/dtkSmartPointer.h
@@ -182,6 +182,7 @@ private:
     T *d;
 };
 
+
 template <class T> inline uint qHash(const dtkSmartPointer<T> &key) {
     return qHash(key.constData());
 }


### PR DESCRIPTION
This is needed for medInria. 
medInria have a cache system for loaded data which is the only object authorized to create SmartPointers. 

I idon't know if this is mergeable in the master of dtk, let me know.