### PR TITLE
Use the COMPONENTS feature of find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,14 +153,15 @@ endif(DTK_ENABLE_COVERAGE)
 ## Dependencies
 ## #################################################################
 
-find_package(Qt5Core        REQUIRED)
-find_package(Qt5Concurrent  REQUIRED)
-find_package(Qt5Quick       REQUIRED)
-find_package(Qt5Network     REQUIRED)
-find_package(Qt5Gui         REQUIRED)
-find_package(Qt5Test        REQUIRED)
-find_package(Qt5Xml         REQUIRED)
-find_package(Qt5Declarative REQUIRED)
+find_package(Qt5 REQUIRED COMPONENTS
+  Core
+  Concurrent
+  Quick
+  Network
+  Gui
+  Test
+  Xml
+  Declarative)
 
 # variables used by doc and tst
 get_target_property(QT5_QMAKE_EXECUTABLE Qt5::qmake LOCATION)

--- a/cmake/dtkConfig.cmake.in
+++ b/cmake/dtkConfig.cmake.in
@@ -37,14 +37,15 @@ set(dtk_INCLUDE_DIRS
 
 include("@CMAKE_BINARY_DIR@/dtkDepends.cmake")
 
-find_package(Qt5Core REQUIRED)
-find_package(Qt5Concurrent REQUIRED)
-find_package(Qt5Declarative REQUIRED)
-find_package(Qt5Network REQUIRED)
-find_package(Qt5Quick REQUIRED)
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5Test REQUIRED)
-find_package(Qt5Xml REQUIRED)
+find_package(Qt5 REQUIRED COMPONENTS
+  Core
+  Concurrent
+  Declarative
+  Network
+  Quick
+  Widgets
+  Test
+  Xml)
 
 ## ###################################################################
 ## Options

--- a/cmake/dtkConfig.install.cmake.in
+++ b/cmake/dtkConfig.install.cmake.in
@@ -33,14 +33,15 @@ set(dtk_INCLUDE_DIRS
 
 include("@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/cmake/dtk/dtkDepends.cmake")
 
-find_package(Qt5Core REQUIRED)
-find_package(Qt5Concurrent REQUIRED)
-find_package(Qt5Declarative REQUIRED)
-find_package(Qt5Network REQUIRED)
-find_package(Qt5Quick REQUIRED)
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5Test REQUIRED)
-find_package(Qt5Xml REQUIRED)
+find_package(Qt5 REQUIRED COMPONENTS
+  Core
+  Concurrent
+  Declarative
+  Network
+  Quick
+  Widgets
+  Test
+  Xml)
 
 ## ###################################################################
 ## Options


### PR DESCRIPTION
To find all needed Qt5 modules.

It ease the act of telling where Qt5 is when configuring cmake. User just have to give the path to the Qt5Config.cmake file.

It's available for cmake 2.8.11