### PR TITLE
add reader and writer classes

### DIFF
--- a/src/dtkMonitoring/CMakeLists.txt
+++ b/src/dtkMonitoring/CMakeLists.txt
@@ -34,10 +34,15 @@ set(${PROJECT_NAME}_HEADERS
   dtkMonitoringList.h
   dtkMonitoringModel
   dtkMonitoringModel.h
+  dtkMonitoringReader
+  dtkMonitoringReader.h
   dtkMonitoringScene
   dtkMonitoringScene.h
   dtkMonitoringView
-  dtkMonitoringView.h)
+  dtkMonitoringView.h
+  dtkMonitoringWriter
+  dtkMonitoringWriter.h
+)
 
 set(${PROJECT_NAME}_SOURCES
   dtkMonitor.cpp
@@ -47,8 +52,12 @@ set(${PROJECT_NAME}_SOURCES
   dtkMonitoringFactory.cpp
   dtkMonitoringList.cpp
   dtkMonitoringModel.cpp
+  dtkMonitoringReader.cpp
   dtkMonitoringScene.cpp
-  dtkMonitoringView.cpp)
+  dtkMonitoringView.cpp
+  dtkMonitoringWriter.cpp
+
+)
 
 set(${PROJECT_NAME}_RCC dtkMonitoring.qrc)
 

--- a/src/dtkMonitoring/dtkMonitoringReader
+++ b/src/dtkMonitoring/dtkMonitoringReader
@@ -1,0 +1,1 @@
+#include "dtkMonitoringReader.h"

--- a/src/dtkMonitoring/dtkMonitoringReader.cpp
+++ b/src/dtkMonitoring/dtkMonitoringReader.cpp
@@ -1,0 +1,92 @@
+#include "dtkMonitoringReader.h"
+#include "dtkMonitor.h"
+#include "dtkMonitoringScene.h"
+#include "dtkMonitoringFactory.h"
+
+class dtkMonitoringReaderPrivate
+{
+public:
+    dtkMonitoringScene* scene;
+};
+
+dtkMonitoringReader::dtkMonitoringReader()
+{
+    d=new dtkMonitoringReaderPrivate();
+}
+
+dtkMonitoringReader::~dtkMonitoringReader()
+{
+    delete d;
+}
+
+void dtkMonitoringReader::setScene(dtkMonitoringScene *scene)
+{
+    d->scene = scene;
+}
+
+void dtkMonitoringReader::read(const QString& filename)
+{
+    QDomDocument doc("dtk");
+    QFile file(filename);
+    if (!file.open(QIODevice::ReadOnly))
+        return;
+    if (!doc.setContent(&file)) {
+        file.close();
+        return;
+    }
+    file.close();
+
+    QDomElement docElem = doc.documentElement();
+
+    QDomNode n = docElem.firstChild();
+    while(!n.isNull()) {
+        QDomElement e = n.toElement(); // try to convert the node to an element.
+        if(!e.isNull()) {
+            if(e.tagName()=="scene") {
+                loadSceneFromElement(e);
+            } else {
+                loadItemFromElement(e);
+            }
+        }
+        n = n.nextSibling();
+    }
+}
+
+void dtkMonitoringReader::loadItemFromElement(const QDomElement& document)
+{
+    QString title,type;
+    double x,y,z,w,h;
+
+    if(document.hasAttribute("title"))
+        title=document.attribute("title");
+    if(document.hasAttribute("type"))
+        type=document.attribute("type");
+
+    if(document.hasAttribute("x"))
+        x=document.attribute("x").toDouble();
+    if(document.hasAttribute("y"))
+        y=document.attribute("y").toDouble();
+    if(document.hasAttribute("z"))
+        z=document.attribute("z").toDouble();
+
+    dtkMonitor* monitor=dtkMonitoringFactory::instance()->create(type);
+    monitor->setPos(monitor->mapFromScene(monitor->pos()));
+    monitor->setZValue(z);
+    d->scene->addItem(monitor);
+}
+
+void dtkMonitoringReader::loadSceneFromElement(const QDomElement& document)
+{
+    double x,y,w,h;
+
+    if(document.hasAttribute("x"))
+        x=document.attribute("x").toDouble();
+    if(document.hasAttribute("y"))
+        y=document.attribute("y").toDouble();
+    if(document.hasAttribute("w"))
+        w=document.attribute("w").toDouble();
+    if(document.hasAttribute("h"))
+        h=document.attribute("h").toDouble();
+
+    d->scene->setSceneRect(x,y,w,h);
+}

--- a/src/dtkMonitoring/dtkMonitoringReader.h
+++ b/src/dtkMonitoring/dtkMonitoringReader.h
@@ -1,0 +1,46 @@
+/* dtkMonitoringReader.h ---
+ *
+ */
+
+/* Commentary:
+ *
+ */
+
+/* Change log:
+ *
+ */
+
+#pragma once
+
+#include "dtkMonitor.h"
+
+#include "dtkMonitoringExport.h"
+
+#include <QtCore>
+
+#include <QDomDocument>
+
+class dtkMonitoringScene;
+class dtkMonitoringReaderPrivate;
+
+class  DTKMONITORING_EXPORT dtkMonitoringReader
+{
+public:
+             dtkMonitoringReader(void);
+    virtual ~dtkMonitoringReader(void);
+
+public:
+    void setScene(dtkMonitoringScene *scene);
+
+public:
+    void read(const QString& filename);
+
+public:
+    void loadSceneFromElement(const QDomElement &document);
+    void loadItemFromElement(const QDomElement &document);
+
+
+private:
+    dtkMonitoringReaderPrivate *d;
+};
+

--- a/src/dtkMonitoring/dtkMonitoringWriter
+++ b/src/dtkMonitoring/dtkMonitoringWriter
@@ -1,0 +1,1 @@
+#include "dtkMonitoringWriter.h"

--- a/src/dtkMonitoring/dtkMonitoringWriter.cpp
+++ b/src/dtkMonitoring/dtkMonitoringWriter.cpp
@@ -1,0 +1,81 @@
+#include "dtkMonitoringWriter.h"
+#include "dtkMonitor.h"
+#include "dtkMonitoringScene.h"
+
+#include <dtkComposer/dtkComposerNode>
+
+class dtkMonitoringWriterPrivate
+{
+public:
+    dtkMonitoringScene* scene;
+};
+
+
+dtkMonitoringWriter::dtkMonitoringWriter()
+{
+    d = new dtkMonitoringWriterPrivate();
+}
+
+dtkMonitoringWriter::~dtkMonitoringWriter()
+{
+    delete d;
+}
+
+void dtkMonitoringWriter::setScene(dtkMonitoringScene *scene)
+{
+    d->scene = scene;
+}
+
+QDomDocument dtkMonitoringWriter::toXML()
+{
+    if(!d->scene)
+        return QDomDocument();
+
+    QDomDocument document("dtk");
+
+    QDomElement root = document.createElement("dtk");
+    document.appendChild(root);
+    QDomElement sceneElmt=document.createElement("scene");
+    sceneElmt.setAttribute("x",d->scene->sceneRect().x());
+    sceneElmt.setAttribute("y",d->scene->sceneRect().y());
+    sceneElmt.setAttribute("w",d->scene->sceneRect().width());
+    sceneElmt.setAttribute("h",d->scene->sceneRect().height());
+
+    root.appendChild(sceneElmt);
+
+
+    for(QGraphicsItem *item:d->scene->items())
+    {
+        dtkMonitor* monitor=dynamic_cast<dtkMonitor*>(item);
+        if(!monitor)
+            continue;
+        QDomElement element=document.createElement("node");
+        toXML(monitor,element);
+        root.appendChild(element);
+    }
+    return document;
+}
+
+void dtkMonitoringWriter::toXML(dtkMonitor* monitor, QDomElement& elmt)
+{
+    if(!monitor)
+        return;
+    elmt.setAttribute("title",monitor->node()->titleHint());
+    elmt.setAttribute("type",monitor->node()->type());
+    elmt.setAttribute("x",monitor->scenePos().x());
+    elmt.setAttribute("y",monitor->scenePos().y());
+    elmt.setAttribute("z",monitor->zValue());
+}
+
+void dtkMonitoringWriter::write(const QString& filename)
+{
+    QDomDocument document=toXML();
+
+    QFile file(filename);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
+          return;
+
+    QTextStream out(&file);
+    out << document.toString();
+    file.close();
+}

--- a/src/dtkMonitoring/dtkMonitoringWriter.h
+++ b/src/dtkMonitoring/dtkMonitoringWriter.h
@@ -1,0 +1,46 @@
+/* dtkMonitoringWriter.h ---
+ *
+ */
+
+/* Commentary:
+ *
+ */
+
+/* Change log:
+ *
+ */
+
+#pragma once
+
+#include "dtkMonitoringExport.h"
+
+#include <QtCore>
+
+#include <QDomDocument>
+
+class dtkMonitor;
+class dtkMonitoringScene;
+class dtkMonitoringWriterPrivate;
+
+class  DTKMONITORING_EXPORT dtkMonitoringWriter
+{
+public:
+             dtkMonitoringWriter(void);
+    virtual ~dtkMonitoringWriter(void);
+
+public:
+    void setScene(dtkMonitoringScene *scene);
+
+public:
+   QDomDocument toXML();
+
+public:
+   void write(const QString& filename);
+
+protected:
+   void toXML(dtkMonitor* monitor, QDomElement& elmt);
+
+private:
+    dtkMonitoringWriterPrivate *d;
+};
+


### PR DESCRIPTION
First step toward monitoring persistence. So far only monitors (and scene viewport) are saved, without their corresponding nodes. 