### PR TITLE
Allow to retrieve metaData from plugins

### DIFF
--- a/src/dtkCore/dtkCorePluginManager.h
+++ b/src/dtkCore/dtkCorePluginManager.h
@@ -49,6 +49,12 @@ public:
 #pragma mark Plugin Queries
 
     QStringList plugins(void);
+    
+#pragma mark -
+#pragma mark MetaData Queries
+
+    QJsonObject metaData(const QString& pluginKey);
+    
 
 protected:
     dtkCorePluginManagerPrivate<T> *d;

--- a/src/dtkCore/dtkCorePluginManager.tpp
+++ b/src/dtkCore/dtkCorePluginManager.tpp
@@ -226,5 +226,16 @@ template <typename T> QStringList dtkCorePluginManager<T>::plugins(void)
     return d->loaders.keys();
 }
 
+// /////////////////////////////////////////////////////////////////
+// metaData Queries
+// /////////////////////////////////////////////////////////////////
+
+template <typename T> QJsonObject dtkCorePluginManager<T>::metaData(const QString& pluginKey)
+{
+    if(d->loaders.keys().contains(pluginKey))
+        return d->loaders[pluginKey]->metaData();
+    return QJsonObject();
+}
+
 //
 // dtkCorePluginManager_t.h ends here


### PR DESCRIPTION
Add a method to the plugin manager so users can access plugin's metadaa (defined in the Json file)